### PR TITLE
fix(core): make the content menu buttons always visible

### DIFF
--- a/packages/core/src/editor/components/content-menu.tsx
+++ b/packages/core/src/editor/components/content-menu.tsx
@@ -121,8 +121,6 @@ export function ContentMenu(props: ContentMenuProps) {
       tippyOptions={{
         offset: [2, 0],
         zIndex: 99,
-        duration: 2000,
-        animation: 'none',
       }}
       onNodeChange={handleNodeChange}
       className={cn(editor.isEditable ? 'mly-visible' : 'mly-hidden')}

--- a/packages/core/src/editor/plugins/drag-handle/drag-handle-plugin.ts
+++ b/packages/core/src/editor/plugins/drag-handle/drag-handle-plugin.ts
@@ -472,17 +472,6 @@ export function DragHandlePlugin(
     },
     props: {
       handleDOMEvents: {
-        mouseleave: (e, event) => (
-          x ||
-            (event.target &&
-              !container.contains(event?.relatedTarget as Node) &&
-              (null == tippyInstance || tippyInstance.hide(),
-              (currentNode = null),
-              (lastNodePos = -1),
-              null == onNodeChange ||
-                onNodeChange({ editor: editor, node: null, pos: -1 }))),
-          false
-        ),
         mousemove(e, t) {
           if (!element || !tippyInstance || x) return false;
           const n = findElementNextToCoords({


### PR DESCRIPTION

Before

https://github.com/user-attachments/assets/26c06f4d-a0fd-4265-bbac-aa8dd02d86f5

After

https://github.com/user-attachments/assets/5b5bfd96-0322-42e9-aa24-052d9196de01