### PR TITLE
fix(render): text node empty value rendering wrong html space

### DIFF
--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -720,15 +720,15 @@ export class Maily {
   }
 
   private text(node: JSONContent, options?: NodeOptions): JSX.Element {
-    const text = node.text || '&nbsp';
     if (node.marks) {
       return this.renderMark(node, options);
     }
 
+    const text = node.text;
     // if it's all empty, return an invisible space length
     // of the text so that it doesn't look empty for inline-images
     const spaces = text?.match(/\s/g);
-    if (spaces && spaces.length === text.length) {
+    if (spaces && spaces.length === text?.length) {
       return (
         <>
           {spaces.map((_, index) => (
@@ -738,7 +738,7 @@ export class Maily {
       );
     }
 
-    return <>{text}</>;
+    return text ? <>{text}</> : <>&nbsp;</>;
   }
 
   private bold(_: MarkType, text: JSX.Element): JSX.Element {


### PR DESCRIPTION
Fixes the issue with rendering the wrong HTML space `&nbsp` instead of `&nbsp;` when the text value is empty.

![image](https://github.com/user-attachments/assets/4f288ae6-d29c-4ecd-b7ea-f2e3d54c1549)

![image](https://github.com/user-attachments/assets/dc3f8cc8-2da2-4a6b-bf8b-0a29ee4c501c)
