### PR TITLE
feat(editor): enhance RepeatBubbleMenu with config prop for description

### DIFF
--- a/packages/core/src/editor/components/repeat-menu/repeat-bubble-menu.tsx
+++ b/packages/core/src/editor/components/repeat-menu/repeat-bubble-menu.tsx
@@ -1,6 +1,10 @@
 import { cn } from '@/editor/utils/classname';
 import { isTextSelected } from '@/editor/utils/is-text-selected';
-import { BubbleMenu, findChildren } from '@tiptap/react';
+import {
+  BubbleMenu,
+  Editor as TiptapEditor,
+  findChildren,
+} from '@tiptap/react';
 import { InfoIcon, Repeat2 } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { sticky } from 'tippy.js';
@@ -21,8 +25,12 @@ import { getClosestNodeByName } from '@/editor/utils/columns';
 import { processVariables } from '@/editor/utils/variable';
 import { useVariableOptions } from '@/editor/utils/node-options';
 
-export function RepeatBubbleMenu(props: EditorBubbleMenuProps) {
-  const { appendTo, editor } = props;
+export function RepeatBubbleMenu(
+  props: EditorBubbleMenuProps & {
+    config?: { description?: (editor: TiptapEditor) => React.ReactNode };
+  }
+) {
+  const { appendTo, editor, config } = props;
   if (!editor) {
     return null;
   }
@@ -203,6 +211,7 @@ export function RepeatBubbleMenu(props: EditorBubbleMenuProps) {
             editor={editor}
           />
         </div>
+        {config?.description && config.description(editor)}
       </TooltipProvider>
     </BubbleMenu>
   );

--- a/packages/core/src/editor/index.tsx
+++ b/packages/core/src/editor/index.tsx
@@ -72,6 +72,7 @@ export function Editor(props: EditorProps) {
     blocks = DEFAULT_SLASH_COMMANDS,
     editable = true,
     placeholderUrl = DEFAULT_PLACEHOLDER_URL,
+    repeatMenuConfig,
   } = props;
 
   const formattedContent = useMemo(() => {
@@ -153,7 +154,11 @@ export function Editor(props: EditorProps) {
           <ColumnsBubbleMenu editor={editor} appendTo={menuContainerRef} />
           <ContentMenu editor={editor} />
           <VariableBubbleMenu editor={editor} appendTo={menuContainerRef} />
-          <RepeatBubbleMenu editor={editor} appendTo={menuContainerRef} />
+          <RepeatBubbleMenu
+            editor={editor}
+            appendTo={menuContainerRef}
+            config={repeatMenuConfig}
+          />
           <HTMLBubbleMenu editor={editor} appendTo={menuContainerRef} />
           <InlineImageBubbleMenu editor={editor} appendTo={menuContainerRef} />
         </div>


### PR DESCRIPTION
it’s basically the same old code that was overridden in one of rebase/merge