### PR TITLE
feat(core): allow to hook into the attributes update

### DIFF
--- a/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
+++ b/packages/core/src/editor/components/image-menu/image-bubble-menu.tsx
@@ -14,10 +14,7 @@ import { Select } from '../ui/select';
 import { TooltipProvider } from '../ui/tooltip';
 import { ImageSize } from './image-size';
 import { useImageState } from './use-image-state';
-import {
-  IMAGE_MAX_HEIGHT,
-  IMAGE_MAX_WIDTH,
-} from '@/editor/nodes/image/image-view';
+import { IMAGE_MAX_WIDTH } from '@/editor/nodes/image/image-view';
 
 export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
   const { editor, appendTo } = props;
@@ -69,7 +66,7 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
                 editor
                   ?.chain()
                   .focus()
-                  .setLogoAttributes({ size: value as AllowedLogoSize })
+                  .updateLogoAttributes({ size: value as AllowedLogoSize })
                   .run();
               }}
             />
@@ -84,12 +81,16 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
             onAlignmentChange={(alignment) => {
               const isCurrentNodeImage = state.isImageActive;
               if (!isCurrentNodeImage) {
-                editor?.chain().focus().setLogoAttributes({ alignment }).run();
+                editor
+                  ?.chain()
+                  .focus()
+                  .updateLogoAttributes({ alignment })
+                  .run();
               } else {
                 editor
                   ?.chain()
                   .focus()
-                  .updateAttributes('image', { alignment })
+                  .updateImageAttributes({ alignment })
                   .run();
               }
             }}
@@ -101,7 +102,7 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
               if (state.isLogoActive) {
                 editor
                   ?.chain()
-                  .setLogoAttributes({
+                  .updateLogoAttributes({
                     src: value,
                     isSrcVariable: isVariable ?? false,
                   })
@@ -109,7 +110,7 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
               } else {
                 editor
                   ?.chain()
-                  .updateAttributes('image', {
+                  .updateImageAttributes({
                     src: value,
                     isSrcVariable: isVariable ?? false,
                   })
@@ -128,7 +129,7 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
               onValueChange={(value, isVariable) => {
                 editor
                   ?.chain()
-                  .updateAttributes('image', {
+                  .updateImageAttributes({
                     externalLink: value,
                     isExternalLinkVariable: isVariable ?? false,
                   })
@@ -155,7 +156,7 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
               onValueChange={(value) => {
                 editor
                   ?.chain()
-                  .updateAttributes('image', {
+                  .updateImageAttributes({
                     borderRadius: Number(value),
                   })
                   .run();
@@ -177,7 +178,7 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
 
                   editor
                     ?.chain()
-                    .updateAttributes('image', {
+                    .updateImageAttributes({
                       width: String(width),
                       ...(lockAspectRatio && value
                         ? {
@@ -202,7 +203,7 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
 
                   editor
                     ?.chain()
-                    .updateAttributes('image', {
+                    .updateImageAttributes({
                       height: String(height),
                       ...(lockAspectRatio && value
                         ? {
@@ -225,7 +226,7 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
 
                   editor
                     ?.chain()
-                    .updateAttributes('image', {
+                    .updateImageAttributes({
                       lockAspectRatio: !lockAspectRatio,
                       aspectRatio,
                     })
@@ -242,9 +243,19 @@ export function ImageBubbleMenu(props: EditorBubbleMenuProps) {
         <ShowPopover
           showIfKey={state.currentShowIfKey}
           onShowIfKeyValueChange={(value) => {
+            if (state.isLogoActive) {
+              editor
+                ?.chain()
+                .updateLogoAttributes({
+                  showIfKey: value,
+                })
+                .run();
+              return;
+            }
+
             editor
               ?.chain()
-              .updateAttributes(state.isLogoActive ? 'logo' : 'image', {
+              .updateImageAttributes({
                 showIfKey: value,
               })
               .run();

--- a/packages/core/src/editor/components/inline-image-menu/inline-image-bubble-menu.tsx
+++ b/packages/core/src/editor/components/inline-image-menu/inline-image-bubble-menu.tsx
@@ -52,7 +52,7 @@ export function InlineImageBubbleMenu(props: EditorBubbleMenuProps) {
             onValueChange={(value, isVariable) => {
               editor
                 ?.chain()
-                .updateAttributes('inlineImage', {
+                .updateInlineImageAttributes({
                   src: value,
                   isSrcVariable: isVariable ?? false,
                 })
@@ -69,7 +69,7 @@ export function InlineImageBubbleMenu(props: EditorBubbleMenuProps) {
             onValueChange={(value, isVariable) => {
               editor
                 ?.chain()
-                .updateAttributes('inlineImage', {
+                .updateInlineImageAttributes({
                   externalLink: value,
                   isExternalLinkVariable: isVariable ?? false,
                 })
@@ -86,7 +86,7 @@ export function InlineImageBubbleMenu(props: EditorBubbleMenuProps) {
             onValueChange={(value) => {
               editor
                 ?.chain()
-                .updateAttributes('inlineImage', {
+                .updateInlineImageAttributes({
                   width: value || DEFAULT_INLINE_IMAGE_WIDTH,
                   height: value || DEFAULT_INLINE_IMAGE_HEIGHT,
                 })

--- a/packages/core/src/editor/components/repeat-menu/repeat-bubble-menu.tsx
+++ b/packages/core/src/editor/components/repeat-menu/repeat-bubble-menu.tsx
@@ -166,7 +166,7 @@ export function RepeatBubbleMenu(
                   placeholder="ie. payload.items"
                   value={state?.each || ''}
                   onValueChange={(value) => {
-                    editor.commands.updateRepeat({
+                    editor.commands.updateRepeatAttributes({
                       each: value,
                     });
                   }}
@@ -174,7 +174,7 @@ export function RepeatBubbleMenu(
                     setIsUpdatingKey(false);
                   }}
                   onSelectOption={(value) => {
-                    editor.commands.updateRepeat({
+                    editor.commands.updateRepeatAttributes({
                       each: value,
                     });
                     setIsUpdatingKey(false);
@@ -191,7 +191,7 @@ export function RepeatBubbleMenu(
             <NumberInput
               value={state.iterations}
               onValueChange={(value) => {
-                editor.commands.updateRepeat({
+                editor.commands.updateRepeatAttributes({
                   iterations: value,
                 });
               }}
@@ -204,7 +204,7 @@ export function RepeatBubbleMenu(
           <ShowPopover
             showIfKey={state.currentShowIfKey}
             onShowIfKeyValueChange={(value) => {
-              editor.commands.updateRepeat({
+              editor.commands.updateRepeatAttributes({
                 showIfKey: value,
               });
             }}

--- a/packages/core/src/editor/components/text-menu/text-bubble-content.tsx
+++ b/packages/core/src/editor/components/text-menu/text-bubble-content.tsx
@@ -104,24 +104,10 @@ export function TextBubbleContent(props: TextBubbleContentProps) {
       <LinkInputPopover
         defaultValue={state?.linkUrl ?? ''}
         onValueChange={(value, isVariable) => {
-          if (!value) {
-            editor
-              ?.chain()
-              .focus()
-              .extendMarkRange('link')
-              .unsetLink()
-              .unsetUnderline()
-              .run();
-            return;
-          }
-
-          editor
-            ?.chain()
-            .extendMarkRange('link')
-            .setLink({ href: value })
-            .setIsUrlVariable(isVariable ?? false)
-            .setUnderline()
-            .run()!;
+          editor?.commands.updateLinkAttributes({
+            href: value,
+            isUrlVariable: isVariable ?? false,
+          });
         }}
         tooltip="External URL"
         editor={editor}

--- a/packages/core/src/editor/nodes/button/button-view.tsx
+++ b/packages/core/src/editor/nodes/button/button-view.tsx
@@ -16,6 +16,7 @@ import { useVariableOptions } from '@/editor/utils/node-options';
 import { NodeViewProps, NodeViewWrapper } from '@tiptap/react';
 import { CSSProperties, useMemo } from 'react';
 import {
+  AllowedButtonBorderRadius,
   allowedButtonBorderRadius,
   AllowedButtonVariant,
   allowedButtonVariant,
@@ -24,7 +25,7 @@ import {
 import { ButtonLabelInput } from './button-label-input';
 
 export function ButtonView(props: NodeViewProps) {
-  const { node, editor, getPos, updateAttributes } = props;
+  const { node, editor, getPos } = props;
   const {
     text,
     isTextVariable,
@@ -147,7 +148,7 @@ export function ButtonView(props: NodeViewProps) {
               <ButtonLabelInput
                 value={text}
                 onValueChange={(value, isVariable) => {
-                  updateAttributes({
+                  editor.commands.updateButton({
                     text: value,
                     isTextVariable: isVariable ?? false,
                   });
@@ -167,8 +168,8 @@ export function ButtonView(props: NodeViewProps) {
                     label: value,
                   }))}
                   onValueChange={(value) => {
-                    updateAttributes({
-                      borderRadius: value,
+                    editor.commands.updateButton({
+                      borderRadius: value as AllowedButtonBorderRadius,
                     });
                   }}
                   tooltip="Border Radius"
@@ -183,8 +184,8 @@ export function ButtonView(props: NodeViewProps) {
                     label: value,
                   }))}
                   onValueChange={(value) => {
-                    updateAttributes({
-                      variant: value,
+                    editor.commands.updateButton({
+                      variant: value as AllowedButtonVariant,
                     });
                   }}
                   tooltip="Style"
@@ -203,7 +204,7 @@ export function ButtonView(props: NodeViewProps) {
                     const { paddingX, paddingY } =
                       sizes[value as 'small' | 'medium' | 'large'];
 
-                    updateAttributes({
+                    editor.commands.updateButton({
                       paddingTop: paddingY,
                       paddingRight: paddingX,
                       paddingBottom: paddingY,
@@ -220,7 +221,7 @@ export function ButtonView(props: NodeViewProps) {
                 <AlignmentSwitch
                   alignment={alignment}
                   onAlignmentChange={(alignment) => {
-                    updateAttributes({
+                    editor.commands.updateButton({
                       alignment,
                     });
                   }}
@@ -229,7 +230,7 @@ export function ButtonView(props: NodeViewProps) {
                 <LinkInputPopover
                   defaultValue={externalLink || ''}
                   onValueChange={(value, isVariable) => {
-                    updateAttributes({
+                    editor.commands.updateButton({
                       url: value,
                       isUrlVariable: isVariable ?? false,
                     });
@@ -247,7 +248,7 @@ export function ButtonView(props: NodeViewProps) {
                   variant={variant}
                   color={buttonColor}
                   onChange={(color) => {
-                    updateAttributes({
+                    editor.commands.updateButton({
                       buttonColor: color,
                     });
                   }}
@@ -256,7 +257,7 @@ export function ButtonView(props: NodeViewProps) {
                 <TextColorPickerPopup
                   color={textColor}
                   onChange={(color) => {
-                    updateAttributes({
+                    editor.commands.updateButton({
                       textColor: color,
                     });
                   }}
@@ -268,7 +269,7 @@ export function ButtonView(props: NodeViewProps) {
               <ShowPopover
                 showIfKey={showIfKey}
                 onShowIfKeyValueChange={(value) => {
-                  updateAttributes({
+                  editor.commands.updateButton({
                     showIfKey: value,
                   });
                 }}

--- a/packages/core/src/editor/nodes/button/button-view.tsx
+++ b/packages/core/src/editor/nodes/button/button-view.tsx
@@ -148,7 +148,7 @@ export function ButtonView(props: NodeViewProps) {
               <ButtonLabelInput
                 value={text}
                 onValueChange={(value, isVariable) => {
-                  editor.commands.updateButton({
+                  editor.commands.updateButtonAttributes({
                     text: value,
                     isTextVariable: isVariable ?? false,
                   });
@@ -168,7 +168,7 @@ export function ButtonView(props: NodeViewProps) {
                     label: value,
                   }))}
                   onValueChange={(value) => {
-                    editor.commands.updateButton({
+                    editor.commands.updateButtonAttributes({
                       borderRadius: value as AllowedButtonBorderRadius,
                     });
                   }}
@@ -184,7 +184,7 @@ export function ButtonView(props: NodeViewProps) {
                     label: value,
                   }))}
                   onValueChange={(value) => {
-                    editor.commands.updateButton({
+                    editor.commands.updateButtonAttributes({
                       variant: value as AllowedButtonVariant,
                     });
                   }}
@@ -204,7 +204,7 @@ export function ButtonView(props: NodeViewProps) {
                     const { paddingX, paddingY } =
                       sizes[value as 'small' | 'medium' | 'large'];
 
-                    editor.commands.updateButton({
+                    editor.commands.updateButtonAttributes({
                       paddingTop: paddingY,
                       paddingRight: paddingX,
                       paddingBottom: paddingY,
@@ -221,7 +221,7 @@ export function ButtonView(props: NodeViewProps) {
                 <AlignmentSwitch
                   alignment={alignment}
                   onAlignmentChange={(alignment) => {
-                    editor.commands.updateButton({
+                    editor.commands.updateButtonAttributes({
                       alignment,
                     });
                   }}
@@ -230,7 +230,7 @@ export function ButtonView(props: NodeViewProps) {
                 <LinkInputPopover
                   defaultValue={externalLink || ''}
                   onValueChange={(value, isVariable) => {
-                    editor.commands.updateButton({
+                    editor.commands.updateButtonAttributes({
                       url: value,
                       isUrlVariable: isVariable ?? false,
                     });
@@ -248,7 +248,7 @@ export function ButtonView(props: NodeViewProps) {
                   variant={variant}
                   color={buttonColor}
                   onChange={(color) => {
-                    editor.commands.updateButton({
+                    editor.commands.updateButtonAttributes({
                       buttonColor: color,
                     });
                   }}
@@ -257,7 +257,7 @@ export function ButtonView(props: NodeViewProps) {
                 <TextColorPickerPopup
                   color={textColor}
                   onChange={(color) => {
-                    editor.commands.updateButton({
+                    editor.commands.updateButtonAttributes({
                       textColor: color,
                     });
                   }}
@@ -269,7 +269,7 @@ export function ButtonView(props: NodeViewProps) {
               <ShowPopover
                 showIfKey={showIfKey}
                 onShowIfKeyValueChange={(value) => {
-                  editor.commands.updateButton({
+                  editor.commands.updateButtonAttributes({
                     showIfKey: value,
                   });
                 }}

--- a/packages/core/src/editor/nodes/button/button.tsx
+++ b/packages/core/src/editor/nodes/button/button.tsx
@@ -49,7 +49,7 @@ declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     button: {
       setButton: () => ReturnType;
-      updateButton: (attrs: Partial<ButtonAttributes>) => ReturnType;
+      updateButtonAttributes: (attrs: Partial<ButtonAttributes>) => ReturnType;
     };
   }
 }
@@ -308,7 +308,7 @@ export const ButtonExtension = Node.create({
             content: [],
           });
         },
-      updateButton: (attrs) => updateAttributes(this.name, attrs),
+      updateButtonAttributes: (attrs) => updateAttributes(this.name, attrs),
     };
   },
 

--- a/packages/core/src/editor/nodes/image/image-view.tsx
+++ b/packages/core/src/editor/nodes/image/image-view.tsx
@@ -19,7 +19,7 @@ export const IMAGE_MAX_HEIGHT = 400;
 export type ImageStatus = 'idle' | 'loading' | 'loaded' | 'error';
 
 export function ImageView(props: NodeViewProps) {
-  const { node, updateAttributes, selected, editor } = props;
+  const { node, selected, editor } = props;
 
   const [status, setStatus] = useState<ImageStatus>('idle');
   const [isPlaceholderImage, setIsPlaceholderImage] = useState(false);
@@ -66,7 +66,14 @@ export function ImageView(props: NodeViewProps) {
         window.removeEventListener('mousemove', mouseMoveHandler);
         window.removeEventListener('mouseup', removeListeners);
         const aspectRatio = getAspectRatio(newWidth, newHeight);
-        updateAttributes({ width: newWidth, height: newHeight, aspectRatio });
+        editor
+          .chain()
+          .updateImageAttributes({
+            width: newWidth,
+            height: newHeight,
+            aspectRatio,
+          })
+          .run();
         setResizingStyle(undefined);
       };
 
@@ -176,7 +183,7 @@ export function ImageView(props: NodeViewProps) {
       try {
         setStatus('loading');
         const imageUrl = await onImageUpload(file);
-        updateAttributes({ src: imageUrl });
+        editor.chain().updateImageAttributes({ src: imageUrl }).run();
         setIsPlaceholderImage(false);
         setStatus('loaded');
       } catch (error) {
@@ -184,7 +191,7 @@ export function ImageView(props: NodeViewProps) {
         setStatus('error');
       }
     },
-    [onImageUpload, updateAttributes]
+    [onImageUpload]
   );
 
   // load the image using new Image() to avoid layout shift
@@ -219,11 +226,14 @@ export function ImageView(props: NodeViewProps) {
         naturalHeight
       );
 
-      updateAttributes({
-        width: Math.min(wrapperWidth, naturalWidth),
-        height: Math.min(calculatedHeight, naturalHeight),
-        aspectRatio,
-      });
+      editor
+        .chain()
+        .updateImageAttributes({
+          width: Math.min(wrapperWidth, naturalWidth),
+          height: Math.min(calculatedHeight, naturalHeight),
+          aspectRatio,
+        })
+        .run();
     };
     img.onerror = () => {
       setStatus('error');

--- a/packages/core/src/editor/nodes/image/image.ts
+++ b/packages/core/src/editor/nodes/image/image.ts
@@ -2,8 +2,33 @@ import TiptapImage from '@tiptap/extension-image';
 import { ReactNodeViewRenderer } from '@tiptap/react';
 import { DEFAULT_SECTION_SHOW_IF_KEY } from '../section/section';
 import { ImageView } from './image-view';
+import { updateAttributes } from '@/editor/utils/update-attribute';
 
 const DEFAULT_IMAGE_BORDER_RADIUS = 0;
+
+export type ImageAttributes = {
+  src: string;
+  isSrcVariable?: boolean;
+  alt?: string;
+  title?: string;
+  externalLink?: string;
+  isExternalLinkVariable?: boolean;
+  alignment?: 'left' | 'center' | 'right';
+  borderRadius?: number;
+  width?: string | number;
+  height?: string | number;
+  aspectRatio?: number;
+  lockAspectRatio?: boolean;
+  showIfKey?: string;
+};
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    imageOverride: {
+      updateImageAttributes: (attrs: Partial<ImageAttributes>) => ReturnType;
+    };
+  }
+}
 
 export const ImageExtension = TiptapImage.extend({
   addAttributes() {
@@ -162,6 +187,16 @@ export const ImageExtension = TiptapImage.extend({
           };
         },
       },
+    };
+  },
+  addCommands() {
+    return {
+      ...this.parent?.(),
+      updateImageAttributes:
+        (attributes) =>
+        ({ chain }) => {
+          return chain().updateAttributes(this.name, attributes).run();
+        },
     };
   },
   addNodeView() {

--- a/packages/core/src/editor/nodes/inline-image/inline-image.tsx
+++ b/packages/core/src/editor/nodes/inline-image/inline-image.tsx
@@ -12,14 +12,22 @@ export interface InlineImageOptions {
 
 export interface InlineImageAttributes {
   src: string;
+  isSrcVariable?: boolean;
   alt?: string;
   title?: string;
+  externalLink?: string;
+  isExternalLinkVariable?: boolean;
+  height?: string | number;
+  width?: string | number;
 }
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     inlineImage: {
       setInlineImage: (options: InlineImageAttributes) => ReturnType;
+      updateInlineImageAttributes: (
+        attrs: Partial<InlineImageAttributes>
+      ) => ReturnType;
     };
   }
 }
@@ -126,6 +134,11 @@ export const InlineImageExtension = Node.create<InlineImageOptions>({
             type: this.name,
             attrs: options,
           });
+        },
+      updateInlineImageAttributes:
+        (attributes) =>
+        ({ chain }) => {
+          return chain().updateAttributes(this.name, attributes).run();
         },
     };
   },

--- a/packages/core/src/editor/nodes/link.ts
+++ b/packages/core/src/editor/nodes/link.ts
@@ -1,9 +1,17 @@
 import TiptapLink from '@tiptap/extension-link';
 
+export type LinkAttributes = {
+  href: string;
+  target?: string | null;
+  rel?: string | null;
+  class?: string | null;
+  isUrlVariable?: boolean;
+};
+
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     customLink: {
-      setIsUrlVariable: (isUrlVariable: boolean) => ReturnType;
+      updateLinkAttributes: (attributes: LinkAttributes) => ReturnType;
     };
   }
 }
@@ -21,10 +29,25 @@ export const LinkExtension = TiptapLink.extend({
     return {
       ...this.parent?.(),
 
-      setIsUrlVariable:
-        (isUrlVariable) =>
+      updateLinkAttributes:
+        (attributes) =>
         ({ chain }) => {
-          return chain().setMark('link', { isUrlVariable }).run();
+          const { isUrlVariable, href, ...attrs } = attributes;
+          if (!href) {
+            return chain()
+              .focus()
+              .extendMarkRange('link')
+              .unsetLink()
+              .unsetUnderline()
+              .run();
+          }
+
+          return chain()
+            .extendMarkRange('link')
+            .setLink({ href, ...attrs })
+            .setMark('link', { isUrlVariable: isUrlVariable ?? false })
+            .setUnderline()
+            .run();
         },
     };
   },

--- a/packages/core/src/editor/nodes/logo/logo-view.tsx
+++ b/packages/core/src/editor/nodes/logo/logo-view.tsx
@@ -8,7 +8,7 @@ import { useImageUploadOptions } from '@/editor/extensions/image-upload/image-up
 import { cn } from '@/editor/utils/classname';
 
 export function LogoView(props: NodeViewProps) {
-  const { node, editor, updateAttributes } = props;
+  const { node, editor } = props;
 
   const [status, setStatus] = useState<ImageStatus>('idle');
   const [isPlaceholderImage, setIsPlaceholderImage] = useState(false);
@@ -46,7 +46,7 @@ export function LogoView(props: NodeViewProps) {
       try {
         setStatus('loading');
         const imageUrl = await onImageUpload(file);
-        updateAttributes({ src: imageUrl });
+        editor.chain().updateLogoAttributes({ src: imageUrl }).run();
         setIsPlaceholderImage(false);
         setStatus('loaded');
       } catch (error) {
@@ -54,7 +54,7 @@ export function LogoView(props: NodeViewProps) {
         setStatus('error');
       }
     },
-    [onImageUpload, updateAttributes]
+    [onImageUpload]
   );
 
   const handleDragOver = useCallback(

--- a/packages/core/src/editor/nodes/logo/logo.ts
+++ b/packages/core/src/editor/nodes/logo/logo.ts
@@ -30,7 +30,7 @@ declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     logo: {
       setLogoImage: (options: LogoOptions) => ReturnType;
-      setLogoAttributes: (attributes: Partial<LogoAttributes>) => ReturnType;
+      updateLogoAttributes: (attributes: Partial<LogoAttributes>) => ReturnType;
     };
   }
 }
@@ -130,10 +130,10 @@ export const LogoExtension = TiptapImage.extend({
             attrs: options,
           });
         },
-      setLogoAttributes:
+      updateLogoAttributes:
         (attributes) =>
-        ({ commands }) => {
-          return commands.updateAttributes('logo', attributes);
+        ({ chain }) => {
+          return chain().updateAttributes(this.name, attributes).run();
         },
     };
   },

--- a/packages/core/src/editor/nodes/repeat/repeat.ts
+++ b/packages/core/src/editor/nodes/repeat/repeat.ts
@@ -15,7 +15,7 @@ declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     repeat: {
       setRepeat: () => ReturnType;
-      updateRepeat: (attrs: Partial<RepeatAttributes>) => ReturnType;
+      updateRepeatAttributes: (attrs: Partial<RepeatAttributes>) => ReturnType;
     };
   }
 }
@@ -116,7 +116,7 @@ export const RepeatExtension = Node.create({
             ],
           });
         },
-      updateRepeat: (attrs) => updateAttributes(this.name, attrs),
+      updateRepeatAttributes: (attrs) => updateAttributes(this.name, attrs),
     };
   },
 

--- a/packages/core/src/extensions.ts
+++ b/packages/core/src/extensions.ts
@@ -12,6 +12,7 @@ export * from './editor/nodes/columns/column';
 export * from './editor/nodes/columns/columns';
 export * from './editor/nodes/footer';
 export * from './editor/nodes/image/image';
+export * from './editor/nodes/inline-image/inline-image';
 export * from './editor/nodes/link';
 export * from './editor/nodes/logo/logo';
 export * from './editor/nodes/repeat/repeat';


### PR DESCRIPTION
Updated the `button-view` component to use the command `updateButton` that updates the attributes instead of using `updateAttributes` as it allows us to hook into that function and override with additional attributes, for example add the `aliasFor`.