### PR TITLE
feat(render): allow dangerously render html, used for the layouts content

### DIFF
--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -787,7 +787,18 @@ export class Maily {
       );
     }
 
-    return text ? <>{text}</> : <>&nbsp;</>;
+    if (!text) {
+      return <>&nbsp;</>;
+    }
+
+    const shouldDangerouslySetInnerHTML =
+      node.attrs?.shouldDangerouslySetInnerHTML ?? false;
+
+    return shouldDangerouslySetInnerHTML ? (
+      <span dangerouslySetInnerHTML={{ __html: text }} />
+    ) : (
+      <>{text}</>
+    );
   }
 
   private bold(_: MarkType, text: JSX.Element): JSX.Element {


### PR DESCRIPTION
In this PR I've extended the `text` node rendering logic to allow dangerously render HTML with attributes argument. This is used for the layout content when layout is created with the Maily editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering raw HTML within text nodes when a specific attribute is set, allowing for more flexible content display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->