### PR TITLE
chore(core,render): allow updating divider margin

### DIFF
--- a/packages/core/src/editor/extensions/horizontal-rule.tsx
+++ b/packages/core/src/editor/extensions/horizontal-rule.tsx
@@ -1,7 +1,41 @@
 import { InputRule } from '@tiptap/core';
 import { HorizontalRule as TipTapHorizontalRule } from '@tiptap/extension-horizontal-rule';
 
+export const DEFAULT_HORIZONTAL_RULE_MARGIN_TOP = 32;
+export const DEFAULT_HORIZONTAL_RULE_MARGIN_BOTTOM = 32;
+
 export const HorizontalRule = TipTapHorizontalRule.extend({
+  addAttributes() {
+    return {
+      marginTop: {
+        default: DEFAULT_HORIZONTAL_RULE_MARGIN_TOP,
+        parseHTML: (element) =>
+          parseInt(
+            element.getAttribute('data-margin-top') ||
+              `${DEFAULT_HORIZONTAL_RULE_MARGIN_TOP}`,
+            10
+          ),
+        renderHTML: (attributes) => ({
+          'data-margin-top': attributes.marginTop,
+          style: `margin-top: ${attributes.marginTop}px`,
+        }),
+      },
+      marginBottom: {
+        default: DEFAULT_HORIZONTAL_RULE_MARGIN_BOTTOM,
+        parseHTML: (element) =>
+          parseInt(
+            element.getAttribute('data-margin-bottom') ||
+              `${DEFAULT_HORIZONTAL_RULE_MARGIN_BOTTOM}`,
+            10
+          ),
+        renderHTML: (attributes) => ({
+          'data-margin-bottom': attributes.marginBottom,
+          style: `margin-bottom: ${attributes.marginBottom}px`,
+        }),
+      },
+    };
+  },
+
   addInputRules() {
     return [
       new InputRule({
@@ -21,6 +55,7 @@ export const HorizontalRule = TipTapHorizontalRule.extend({
       }),
     ];
   },
+
   addOptions() {
     return {
       HTMLAttributes: {

--- a/packages/render/src/maily.tsx
+++ b/packages/render/src/maily.tsx
@@ -979,12 +979,32 @@ export class Maily {
     return formattedVariable;
   }
 
-  private horizontalRule(_: JSONContent, __?: NodeOptions): JSX.Element {
+  private horizontalRule(node: JSONContent, __?: NodeOptions): JSX.Element {
+    const DEFAULT_MARGIN_Y = 32;
+    const { attrs } = node;
+    const {
+      marginTop = DEFAULT_MARGIN_Y,
+      marginRight = 0,
+      marginBottom = DEFAULT_MARGIN_Y,
+      marginLeft = 0,
+
+      paddingTop = 0,
+      paddingRight = 0,
+      paddingBottom = 0,
+      paddingLeft = 0,
+    } = attrs || {};
+
     return (
       <Hr
         style={{
-          marginTop: '32px',
-          marginBottom: '32px',
+          marginTop,
+          marginRight,
+          marginBottom,
+          marginLeft,
+          paddingTop,
+          paddingRight,
+          paddingBottom,
+          paddingLeft,
         }}
       />
     );


### PR DESCRIPTION
In this PR, I've updated the horizontal-rule extension and the rendering logic to allow the use of margin styles. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Horizontal rules now support customizable top and bottom margins, allowing for more flexible spacing in documents.
* **Enhancements**
  * Margin and padding values for horizontal rules are now applied dynamically based on attributes, enabling more precise control over layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->