### PR TITLE
fix(core): calculate the image height based on the aspect ratio when is locked

### DIFF
--- a/packages/core/src/editor/nodes/image/image-view.tsx
+++ b/packages/core/src/editor/nodes/image/image-view.tsx
@@ -96,7 +96,10 @@ export function ImageView(props: NodeViewProps) {
 
         // If aspect ratio is locked, calculate height based on aspect ratio
         if (node.attrs.lockAspectRatio) {
-          newHeight = getNewHeight(newWidth, node.attrs.aspectRatio);
+          const aspectRatio = node.attrs.aspectRatio
+            ? node.attrs.aspectRatio
+            : getAspectRatio(newWidth, newHeight);
+          newHeight = getNewHeight(newWidth, aspectRatio);
         }
 
         setResizingStyle({ width: newWidth, height: newHeight });


### PR DESCRIPTION
Fix for calculating the image height when the aspect ratio is locked. 


https://github.com/user-attachments/assets/576b6c0f-385a-452e-b92d-e4745807da70



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image resizing with locked aspect ratio to maintain correct proportions even when no preset ratio exists.
  * Prevents distortion and unexpected jumps during drag-resize by reliably deriving the aspect ratio from current dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->