### PR TITLE
fix(core): editor inline decoration tippy popover placement

### DIFF
--- a/packages/core/src/editor/extensions/inline-decorator/inline-decorator-list.tsx
+++ b/packages/core/src/editor/extensions/inline-decorator/inline-decorator-list.tsx
@@ -189,6 +189,22 @@ function createAllowHandler() {
 }
 
 /**
+ * Creates a reference client rect getter with fallback to decoration node's sibling
+ */
+function createGetReferenceClientRect(props: any): GetReferenceClientRect {
+  return () => {
+    const originalRect = props.clientRect();
+    if (originalRect.width === 0 && originalRect.height === 0) {
+      const previousSibling = props.decorationNode?.parentElement?.previousElementSibling;
+      if (previousSibling) {
+        return previousSibling.getBoundingClientRect();
+      }
+    }
+    return originalRect;
+  };
+}
+
+/**
  * Creates and manages the tippy popup instance
  */
 function createTippyPopupManager() {
@@ -206,18 +222,8 @@ function createTippyPopupManager() {
         return;
       }
 
-      const getReferenceClientRect: GetReferenceClientRect = () => {
-        // If the original clientRect returns 0,0, try to find the widget decoration
-        const originalRect = props.clientRect();
-        if (originalRect.width === 0 && originalRect.height === 0) {
-          return props.decorationNode.parentElement.previousElementSibling.getBoundingClientRect();
-        }
-        
-        return originalRect;
-      };
-
       popup = tippy('body', {
-        getReferenceClientRect,
+        getReferenceClientRect: createGetReferenceClientRect(props),
         appendTo: () => document.body,
         content: component.element,
         showOnCreate: true,
@@ -234,18 +240,8 @@ function createTippyPopupManager() {
         return;
       }
 
-      const getReferenceClientRect: GetReferenceClientRect = () => {
-        // If the original clientRect returns 0,0, try to find the widget decoration
-        const originalRect = props.clientRect();
-        if (originalRect.width === 0 && originalRect.height === 0) {
-          return props.decorationNode.parentElement.previousElementSibling.getBoundingClientRect();
-        }
-        
-        return originalRect;
-      };
-
       popup?.[0]?.setProps({
-        getReferenceClientRect,
+        getReferenceClientRect: createGetReferenceClientRect(props),
       });
     },
 

--- a/packages/core/src/editor/extensions/inline-decorator/inline-decorator-list.tsx
+++ b/packages/core/src/editor/extensions/inline-decorator/inline-decorator-list.tsx
@@ -206,8 +206,18 @@ function createTippyPopupManager() {
         return;
       }
 
+      const getReferenceClientRect: GetReferenceClientRect = () => {
+        // If the original clientRect returns 0,0, try to find the widget decoration
+        const originalRect = props.clientRect();
+        if (originalRect.width === 0 && originalRect.height === 0) {
+          return props.decorationNode.parentElement.previousElementSibling.getBoundingClientRect();
+        }
+        
+        return originalRect;
+      };
+
       popup = tippy('body', {
-        getReferenceClientRect: props.clientRect as GetReferenceClientRect,
+        getReferenceClientRect,
         appendTo: () => document.body,
         content: component.element,
         showOnCreate: true,
@@ -224,8 +234,18 @@ function createTippyPopupManager() {
         return;
       }
 
+      const getReferenceClientRect: GetReferenceClientRect = () => {
+        // If the original clientRect returns 0,0, try to find the widget decoration
+        const originalRect = props.clientRect();
+        if (originalRect.width === 0 && originalRect.height === 0) {
+          return props.decorationNode.parentElement.previousElementSibling.getBoundingClientRect();
+        }
+        
+        return originalRect;
+      };
+
       popup?.[0]?.setProps({
-        getReferenceClientRect: props.clientRect as GetReferenceClientRect,
+        getReferenceClientRect,
       });
     },
 


### PR DESCRIPTION
Fix for the "translations popover" placement when the cursor is put close to the translation pill, before it was rendering related to the editor position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved positioning of inline decoration popups/tooltips when the selection target has zero size, preventing misaligned or missing popups.
  * Ensured fallback positioning is applied both when popups first appear and during subsequent updates for consistent behavior.
  * Increased reliability of editor overlays for more predictable formatting and annotation interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->